### PR TITLE
Needs GHC >= 7.6 due to Data.IORef.atomicModifyIORef

### DIFF
--- a/hscuid.cabal
+++ b/hscuid.cabal
@@ -40,7 +40,7 @@ library
   hs-source-dirs:      lib
   exposed-modules:     Web.Cuid
   other-modules:       Web.Cuid.Internal
-  build-depends:       base ==4.*,
+  build-depends:       base >= 4.6 && < 5,
                        formatting ==6.*,
                        time ==1.*,
                        random ==1.*,


### PR DESCRIPTION
I've revised existing versions (https://hackage.haskell.org/package/hscuid-1.1.0/revisions/) so a new release is only needed if you wish to add backwards compatibility.
