### PR TITLE
Improve performance by doing formatting ourselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 *.swp
+/.stack-work/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ I am currently developing with Stack.
 To install dependencies and compile the library and test suites:
 
 ```sh
-stack init --resolver nightly
 stack build
 ```
 

--- a/hscuid.cabal
+++ b/hscuid.cabal
@@ -39,7 +39,7 @@ library
     extra-libraries:   kernel32
   else
     build-depends:     unix >= 2.6
-  ghc-options:         -Wall
+  ghc-options:         -Wall -O2
 
 test-suite hscuid-test
   type:                exitcode-stdio-1.0

--- a/hscuid.cabal
+++ b/hscuid.cabal
@@ -26,9 +26,8 @@ source-repository head
 library
   hs-source-dirs:      lib
   exposed-modules:     Web.Cuid
-  other-modules:       Web.Cuid.Internal
+  other-modules:       Web.Cuid.Internal Web.Cuid.Internal.Formatting
   build-depends:       base >= 4.6 && < 5,
-                       formatting >= 6.2,
                        time >= 1.4,
                        random >= 1.0,
                        transformers >= 0.4,

--- a/lib/Web/Cuid.hs
+++ b/lib/Web/Cuid.hs
@@ -16,7 +16,6 @@ import Control.Monad (liftM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.String (fromString)
 import Data.Text (Text)
-import Formatting (sformat)
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid, mconcat)
@@ -36,17 +35,17 @@ newCuid = concatResults [c, time, count, fingerprint, random, random] where
 
     -- The second chunk is the timestamp. Note that this means it is possible
     -- to determine the time a particular CUID was created.
-    time = liftM (sformat number) getTimestamp
+    time = liftM formatNumber getTimestamp
 
     -- To avoid collisions in the same process, add a global counter to each ID.
-    count = liftM (sformat numberPadded) getNextCount
+    count = liftM formatPadded getNextCount
 
     -- To avoid collisions between separate machines, generate a 'fingerprint'
     -- from details which are hopefully unique to this machine - PID and hostname.
     fingerprint = return myFingerprint
 
     -- And some actual randomness for good measure.
-    random = liftM (sformat numberPadded) getRandomValue
+    random = liftM formatPadded getRandomValue
 
 -- | A Slug is not a Cuid. But it is also a strict Text.
 type Slug = Text
@@ -55,9 +54,9 @@ type Slug = Text
 -- techniques as CUIDs.
 newSlug :: MonadIO m => m Slug
 newSlug = concatResults [time, count, fingerprint, random] where
-    time = liftM (sformat shortNumber) getTimestamp
-    count = liftM (sformat numberPadded) getNextCount
-    random = liftM (sformat shortNumber) getRandomValue
+    time = liftM formatShort getTimestamp
+    count = liftM formatPadded getNextCount
+    random = liftM formatShort getRandomValue
     fingerprint = return myFingerprint
 
 -- Evaluate IO actions and concatenate their results.

--- a/lib/Web/Cuid/Internal/Formatting.hs
+++ b/lib/Web/Cuid/Internal/Formatting.hs
@@ -1,0 +1,88 @@
+{-|
+Stability: unstable
+Portability: portable
+
+Contains low-level number-formatting functions for CUIDs.
+-}
+module Web.Cuid.Internal.Formatting (
+    blockSize, formatBase,
+    formatNumber, formatPadded, formatShort
+) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+-- | These constants are to do with the desired output formatting of numbers in
+-- the CUID.
+formatBase, blockSize :: Int
+formatBase = 36
+blockSize = 4
+
+-- | Expresses the given number as a list of digits in the given base. The
+-- "digits" are just integers. The first element of the list is the most
+-- significant digit and the last element is the least significant.
+--
+-- > digitsInBase 10 1234 = [1, 2, 3, 4]
+-- > digitsInBase 16 1234 = [4, 13, 2]    -- "0x4D2" in the usual notation
+digitsInBase :: Integral a => a -> a -> [a]
+digitsInBase base' n' = go base' n' []
+    where go base n accum
+            | n == 0    = if null accum then [0] else accum
+            | n < base  = [n] ++ accum
+            | otherwise = go base q ([r] ++ accum)
+                where (q, r) = quotRem n base
+
+-- | Converts a single integer to a textual digit. The integer can be any value
+-- between 0 and 35, inclusive; the numbers 10 through 35 are converted to the
+-- lowercase letters "a" through "z".
+numberToDigit :: Integral a => a -> Char
+numberToDigit n_
+    | n < 0     = error "numberToDigit: input is negative"
+    | n < 10    = toEnum (n + 48)
+    | n < 36    = toEnum (n + 97 - 10)
+    | otherwise = error "numberToDigit: input is too large"
+    where n = fromIntegral n_
+
+-- | Returns the textual representation of the given integer in the given base.
+--
+-- > formatInBase 10 999 = "999"
+-- > formatInBase 16 999 = "3e7"
+-- > formatInBase 36 999 = "rr"
+formatInBase :: Integral a => a -> a -> Text
+formatInBase base n = T.pack $ map numberToDigit $ digitsInBase base n
+
+-- | Returns the textual representation of the given integer in the given base,
+-- padded on the left with zeroes so that the string is /at least/ the given
+-- number of digits long.
+--
+-- > formatPaddedInBase 10 3 1 = "001"
+-- > formatPaddedInBase 10 3 12 = "012"
+-- > formatPaddedInBase 10 3 123 = "123"
+-- > formatPaddedInBase 10 3 1234 = "1234"
+formatPaddedInBase :: Integral a => a -> a -> a -> Text
+formatPaddedInBase base d n = T.justifyRight digits '0' $ formatInBase base n
+    where digits = fromIntegral d
+
+-- | Returns the textual representation of the first (i.e. most significant) two
+-- digits of the given integer in the given base. If the number is only one
+-- digit long then the resulting Text will be only one character long.
+--
+-- > formatShortInBase 10 8 = "8"
+-- > formatShortInBase 10 86 = "86"
+-- > formatShortInBase 10 867 = "86"
+formatShortInBase :: Integral a => a -> a -> Text
+formatShortInBase base n = T.take 2 $ formatInBase base n
+
+-- | 'formatInBase' specialized to use the application's value of 'formatBase'.
+formatNumber :: Int -> Text
+formatNumber = formatInBase formatBase
+
+-- | 'formatPaddedInBase' specialized to use the application's values of
+-- 'formatBase' and 'blockSize'.
+formatPadded :: Int -> Text
+formatPadded = formatPaddedInBase formatBase blockSize
+
+-- | 'formatShortInBase' specialized to use the application's value of
+-- 'formatBase'.
+formatShort :: Int -> Text
+formatShort = formatShortInBase formatBase

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,2 @@
+resolver: lts-8.9
+packages: ['.']


### PR DESCRIPTION
This PR replaces use of the `formatting` library with custom functions. In my testing, this reduces CUID generation time by about half (see #3). Before:

```
time                 3.758 μs   (3.699 μs .. 3.827 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 3.781 μs   (3.728 μs .. 3.835 μs)
```

After:

```
time                 1.919 μs   (1.892 μs .. 1.948 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 1.916 μs   (1.878 μs .. 1.954 μs)
```

I also added a `stack.yaml` to version control so that developers using Stack wouldn’t have to run `stack init` every time.